### PR TITLE
test: use Jest's `changedSince` over `onlyChanged`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - run: |
-        git fetch --no-tags --prune --depth=1 origin master
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
     - name: Use Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Node.js Cross-platform CI
+name: tests(push) - install, lint, test:changedsince
 
 on: [push]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - run: |
-        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
-        git checkout -b master
+        git checkout -b master --track origin/master 
         git checkout ${{ github.event.pull_request.head.sha }}
     - name: Use Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
       uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       run: npm run lint
       env:
         CI: true  
-    - name: npm run test:onlychanged
-      run: npm run test:onlychanged
+    - name: npm run test:changedsince
+      run: npm run test:changedsince
       env:
         CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - run: |
+        git fetch --no-tags --depth=1 origin master
         git checkout -b master --track origin/master 
         git checkout ${{ github.event.pull_request.head.sha }}
     - name: Use Node.js ${{ matrix.node-version }} on ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         node-version: [10.x, 12.x]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - run: |
         git fetch --no-tags --depth=1 origin master
         git checkout -b master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         node-version: [10.x, 12.x]
     steps:
     - uses: actions/checkout@v1
-      run: |
+    - run: |
         git fetch --no-tags --prune --depth=1 origin master
     - name: Use Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
       uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v1
     - run: |
         git fetch --no-tags --depth=1 origin master
-        git checkout -b master --track origin/master 
+        git checkout -b master
         git checkout ${{ github.event.pull_request.head.sha }}
     - name: Use Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
       uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
         node-version: [10.x, 12.x]
     steps:
     - uses: actions/checkout@v1
+      run: |
+        git fetch --no-tags --prune --depth=1 origin master
     - name: Use Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     - uses: actions/checkout@v1
     - run: |
         git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+        git checkout -b master
+        git checkout ${{ github.event.pull_request.head.sha }}
     - name: Use Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
       uses: actions/setup-node@v1
       with:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest --coverage",
     "test:onlychanged": "jest --onlyChanged --coverage",
-    "test:changedsince": "jest --changedSince master --coverage",
+    "test:changedsince": "jest --changedSince=master --coverage",
     "lint": "standard"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "jest --coverage",
     "test:onlychanged": "jest --onlyChanged --coverage",
+    "test:changedsince": "jest --changedSince master --coverage",
     "lint": "standard"
   },
   "keywords": [],


### PR DESCRIPTION
This changes our CI to leverage Jest's `--changedSince` flag over the `--onlyChanged` flag since in my local testing it seemed that there were cases in which it only diffed from the previous commit rather than from the base branch (in our case, `master`). 

I could be wrong on this, doing more investigation now, but wanted to get this up as a potential solution.