### PR TITLE
fix:  Ignore node_modules when linting *.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test:unit": "jest --coverage",
     "test:onlychanged": "jest --onlyChanged --coverage",
-    "test:markdown": "markdownlint . --ignore ./node_modules",
+    "test:markdown": "markdownlint . --ignore-path .gitignore",
     "lint": "standard",
     "test": "npm run lint && npm run test:unit && npm run test:markdown"
   },


### PR DESCRIPTION
The `test:markdown` script was running on all children directories `./**/node_modules` as well;
so instead of ignoring just `./node_modules` we can ignore the files & directories mentioned in `.gitignore` file as follows.

`"test:markdown": "markdownlint . --ignore-path .gitignore",`