### PR TITLE
fix(examples): :bug: Log the names which are saved in the file.

### DIFF
--- a/cli/commander/fake-names-generator/bin/cli.js
+++ b/cli/commander/fake-names-generator/bin/cli.js
@@ -32,10 +32,10 @@ if (program.info) {
   log.dim(`\nGenerating ${program.times} names \n`)
 }
 
-// always logs the generated names
-logNames(program.times, program.nameType)
-
 // Saves the generated names as JSON file.
 if (program.save) {
   saveNames(program.times, program.nameType)
+} else {
+  // always logs the generated names
+  logNames(program.times, program.nameType)
 }

--- a/cli/commander/fake-names-generator/lib/fake-names.js
+++ b/cli/commander/fake-names-generator/lib/fake-names.js
@@ -29,6 +29,7 @@ exports.logNames = (times, nameType) => {
 // Saves the generated names in a JSON File
 exports.saveNames = (times, nameType) => {
   const names = this.generateNames(times, nameType)
+  names.forEach(name => console.log(name))
   const data = JSON.stringify({ names })
   fs.writeFileSync(getFileName(), data)
   log.success(`\n✅ Saved ${times} names to ${getFileName()}\n`)


### PR DESCRIPTION
When saving the results into a file, the log prints wrong names. Here is the fix for the #35